### PR TITLE
Fix build for addon docs config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -29,3 +29,4 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+/config/addon-docs.js


### PR DESCRIPTION
Add /config/addon-docs.js to npm ignore to fix builds on Travis CI.